### PR TITLE
Stop swallowing OAuth2::Error when building access token.

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -73,8 +73,6 @@ module OmniAuth
       def build_access_token
         verifier = request.params['code']
         client.auth_code.get_token(verifier, {:redirect_uri => callback_url}.merge(options.token_params.to_hash(:symbolize_keys => true)))
-      rescue ::OAuth2::Error => e
-        raise e.response.inspect
       end
 
       # An error that is indicated in the OAuth 2.0 callback.


### PR DESCRIPTION
Otherwise Facebook errors will be raised as an runtime exception
which won't be passed by the on_failure callback.
