### PR TITLE
Add expiry info to credentials part of auth hash

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -35,7 +35,9 @@ module OmniAuth
 
       credentials do
         hash = {'token' => access_token.token}
-        hash.merge!('refresh_token' => access_token.refresh_token) if access_token.expires?
+        hash.merge!('refresh_token' => access_token.refresh_token) if access_token.expires? && access_token.refresh_token
+        hash.merge!('expires_at' => access_token.expires_at) if access_token.expires?
+        hash.merge!('expires' => access_token.expires?)
         hash
       end
 


### PR DESCRIPTION
I think it makes sense to include expiry info as part of credentials hash. This also leaves out the `refresh_token` unless it's non-nil. 

What do you think?
