### PR TITLE
Handle socket errors

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -68,6 +68,8 @@ module OmniAuth
         fail!(:invalid_response, e)
       rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
         fail!(:timeout, e)
+      rescue ::SocketError => e
+        fail!(:failed_to_connect, e)
       end
 
       protected


### PR DESCRIPTION
Avoids throwing exceptions during DNS resolution failures.
