### PR TITLE
Require timeout, so rescue ::Timeout::Error does not cause a NameError

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -2,6 +2,7 @@ require 'cgi'
 require 'uri'
 require 'oauth2'
 require 'omniauth'
+require 'timeout'
 
 module OmniAuth
   module Strategies


### PR DESCRIPTION
Without this, I get an error when there is an error during the callback (under 1.9.2 and 1.9.3).

```
NameError: uninitialized constant Timeout
~/.rvm/gems/ruby-1.9.3-p0/gems/omniauth-oauth2-1.0.0/lib/omniauth/strategies/oauth2.rb:69:in `rescue in callback_phase'
~/.rvm/gems/ruby-1.9.3-p0/gems/omniauth-oauth2-1.0.0/lib/omniauth/strategies/oauth2.rb:57:in `callback_phase'
~/.rvm/gems/ruby-1.9.3-p0/gems/omniauth-1.0.2/lib/omniauth/strategy.rb:204:in `callback_call'
~/.rvm/gems/ruby-1.9.3-p0/gems/omniauth-1.0.2/lib/omniauth/strategy.rb:166:in `call!'
~/.rvm/gems/ruby-1.9.3-p0/gems/omniauth-1.0.2/lib/omniauth/strategy.rb:148:in `call'
~/.rvm/gems/ruby-1.9.3-p0/gems/omniauth-1.0.2/lib/omniauth/builder.rb:42:in `call'
~/.rvm/gems/ruby-1.9.3-p0/gems/rack-1.3.6/lib/rack/session/abstract/id.rb:195:in `context'
~/.rvm/gems/ruby-1.9.3-p0/gems/rack-1.3.6/lib/rack/session/abstract/id.rb:190:in `call'
~/Library/Application Support/Pow/Versions/0.3.2/node_modules/nack/lib/nack/server.rb:146:in `handle'
~/Library/Application Support/Pow/Versions/0.3.2/node_modules/nack/lib/nack/server.rb:99:in `rescue in block (2 levels) in start'
~/Library/Application Support/Pow/Versions/0.3.2/node_modules/nack/lib/nack/server.rb:96:in `block (2 levels) in start'
~/Library/Application Support/Pow/Versions/0.3.2/node_modules/nack/lib/nack/server.rb:86:in `each'
~/Library/Application Support/Pow/Versions/0.3.2/node_modules/nack/lib/nack/server.rb:86:in `block in start'
~/Library/Application Support/Pow/Versions/0.3.2/node_modules/nack/lib/nack/server.rb:66:in `loop'
~/Library/Application Support/Pow/Versions/0.3.2/node_modules/nack/lib/nack/server.rb:66:in `start'
~/Library/Application Support/Pow/Versions/0.3.2/node_modules/nack/lib/nack/server.rb:13:in `run'
~/Library/Application Support/Pow/Versions/0.3.2/node_modules/nack/bin/nack_worker:4:in `<main>'
```
