### PR TITLE
deep symbolize keys for oauth client options

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -27,7 +27,7 @@ module OmniAuth
       attr_accessor :access_token
 
       def client
-        ::OAuth2::Client.new(options.client_id, options.client_secret, options.client_options.inject({}){|h,(k,v)| h[k.to_sym] = v; h})
+        ::OAuth2::Client.new(options.client_id, options.client_secret, deep_symbolize(options.client_options))
       end
 
       def callback_url
@@ -74,6 +74,13 @@ module OmniAuth
       end
 
       protected
+
+      def deep_symbolize(hash)
+        hash.inject({}) do |h, (k,v)|
+          h[k.to_sym] = v.is_a?(Hash) ? deep_symbolize(v) : v
+          h
+        end
+      end
 
       def build_access_token
         verifier = request.params['code']

--- a/spec/omniauth/strategies/oauth2_spec.rb
+++ b/spec/omniauth/strategies/oauth2_spec.rb
@@ -11,6 +11,11 @@ describe OmniAuth::Strategies::OAuth2 do
       instance = subject.new(app, :client_options => {'authorize_url' => 'https://example.com'})
       instance.client.options[:authorize_url].should == 'https://example.com'
     end
+
+    it 'should set ssl options as connection options' do
+      instance = subject.new(app, :client_options => {'ssl' => {'ca_path' => 'foo'}})
+      instance.client.options[:connection_opts][:ssl] =~ {:ca_path => 'foo'}
+    end
   end
 
   describe '#authorize_params' do


### PR DESCRIPTION
oauth2 client expects options to be symbols, this patch
will deep symbolize all client option keys before
initializing an oauth2 client.
