### PR TITLE
Bump oauth2 to ~> 0.7.0

### DIFF
--- a/omniauth-oauth2.gemspec
+++ b/omniauth-oauth2.gemspec
@@ -3,7 +3,7 @@ require File.expand_path('../lib/omniauth-oauth2/version', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.add_dependency 'omniauth', '~> 1.0'
-  gem.add_dependency 'oauth2', '~> 0.6.0'
+  gem.add_dependency 'oauth2', '~> 0.7.0'
 
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'rack-test'


### PR DESCRIPTION
```
Bundler could not find compatible versions for gem "oauth2":
  In Gemfile:
    omniauth-oauth2 (>= 0) ruby depends on
      oauth2 (~> 0.5.0) ruby

    oauth-plugin (~> 0.4.0) ruby depends on
      oauth2 (0.7.1)
```

Thanks!
