### PR TITLE
add license information to the gemspec

### DIFF
--- a/omniauth-oauth2.gemspec
+++ b/omniauth-oauth2.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{An abstract OAuth2 strategy for OmniAuth.}
   gem.summary       = %q{An abstract OAuth2 strategy for OmniAuth.}
   gem.homepage      = "https://github.com/intridea/omniauth-oauth2"
+  gem.license       = "MIT"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
this way it can be used with rubygems.org API
