### PR TITLE
Preserve state passed in to authorize_params

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -50,7 +50,7 @@ module OmniAuth
       end
 
       def authorize_params
-        options.authorize_params[:state] = SecureRandom.hex(24)
+        options.authorize_params[:state] ||= SecureRandom.hex(24)
         params = options.authorize_params.merge(options.authorize_options.inject({}){|h,k| h[k.to_sym] = options[k] if options[k]; h})
         if OmniAuth.config.test_mode
           @env ||= {}


### PR DESCRIPTION
I know there's a lot of work being done that directly impacts the state logic, so this PR might be DOA, but I wanted to get the tests green.

Right now the authorize_params method is overwriting any state value passed into it with a randomly generated value.  This is seemingly contrary to the intention of the method, is definitely contrary to the intention expressed in the OAuth 2 spec, and causes several tests to fail.

This minor change preserves a passed in state value if it is present.  It also gets the tests running green.
