### PR TITLE
add faraday timeout support

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -80,7 +80,7 @@ module OmniAuth
         fail!(:invalid_credentials, e)
       rescue ::MultiJson::DecodeError => e
         fail!(:invalid_response, e)
-      rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
+      rescue ::Timeout::Error, ::Errno::ETIMEDOUT, Faraday::Error::TimeoutError => e
         fail!(:timeout, e)
       rescue ::SocketError => e
         fail!(:failed_to_connect, e)


### PR DESCRIPTION
Some oauth2 strategy use faraday as the http client,when there is a timeout error ,ominiauth-oauth2 can not rescue that error.
