### PR TITLE
Add an error #message method so the details will be displayed in the log

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -109,6 +109,10 @@ module OmniAuth
           self.error_reason = error_reason
           self.error_uri = error_uri
         end
+
+        def message
+          [self.error, self.error_reason, self.error_uri].compact.join(' | ')
+        end
       end
     end
   end

--- a/spec/omniauth/strategies/oauth2_spec.rb
+++ b/spec/omniauth/strategies/oauth2_spec.rb
@@ -61,3 +61,20 @@ describe OmniAuth::Strategies::OAuth2 do
     end
   end
 end
+
+describe OmniAuth::Strategies::OAuth2::CallbackError do
+  let(:error){ Class.new(OmniAuth::Strategies::OAuth2::CallbackError) }
+  describe '#message' do
+    subject { error }
+    it "should include all of the attributes" do
+      instance = subject.new('error', 'description', 'uri')
+      instance.message.should =~ /error/
+      instance.message.should =~ /description/
+      instance.message.should =~ /uri/
+    end
+    it "should include all of the attributes" do
+      instance = subject.new(nil, :symbol)
+      instance.message.should == 'symbol'
+    end
+  end
+end


### PR DESCRIPTION
`(google_oauth2) Authentication failure! invalid_credentials: OmniAuth::Strategies::OAuth2::CallbackError, OmniAuth::Strategies::OAuth2::CallbackError` is not very helpful. The details want to get out! Let them out!
