### PR TITLE
Adds catching for Faraday::Error::ConnectionFailed

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -82,7 +82,7 @@ module OmniAuth
         fail!(:invalid_response, e)
       rescue ::Timeout::Error, ::Errno::ETIMEDOUT, Faraday::Error::TimeoutError => e
         fail!(:timeout, e)
-      rescue ::SocketError => e
+      rescue ::SocketError, Faraday::Error::ConnectionFailed => e
         fail!(:failed_to_connect, e)
       end
 


### PR DESCRIPTION
We are seeing this exception in production and I think this is the way to handle it.
