### PR TITLE
Convert specs to RSpec 2.14.7 syntax with Transpec

### DIFF
--- a/spec/omniauth/strategies/oauth2_spec.rb
+++ b/spec/omniauth/strategies/oauth2_spec.rb
@@ -70,7 +70,7 @@ describe OmniAuth::Strategies::OAuth2 do
     subject { fresh_strategy }
     it 'calls fail with the client error received' do
       instance = subject.new('abc', 'def')
-      instance.stub(:request) do
+      allow(instance).to receive(:request) do
         double('Request', :params => {'error_reason' => 'user_denied', 'error' => 'access_denied'})
       end
 


### PR DESCRIPTION
This conversion is done by Transpec 1.10.4 with the following command:
    transpec
- 1 conversion
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
