### PR TITLE
RSpec 3.0.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'json', :platforms => [:jruby, :ruby_18, :ruby_19]
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
   gem 'rack-test'
-  gem 'rspec', '~> 2.14'
+  gem 'rspec', '~> 3.0.0'
   gem 'rubocop', '>= 0.21', :platforms => [:ruby_19, :ruby_20, :ruby_21]
   gem 'simplecov', :require => false
   gem 'webmock'

--- a/Rakefile
+++ b/Rakefile
@@ -8,10 +8,10 @@ task :test => :spec
 
 begin
   require 'rubocop/rake_task'
-  Rubocop::RakeTask.new
+  RuboCop::RakeTask.new
 rescue LoadError
   task :rubocop do
-    $stderr.puts 'Rubocop is disabled'
+    $stderr.puts 'RuboCop is disabled'
   end
 end
 


### PR DESCRIPTION
1. Update to RSpec 3.0.x
2. Fix typo in RuboCop to get specs green
