### PR TITLE
Support for Dynamic Client Credentials

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -33,9 +33,15 @@ module OmniAuth
       attr_accessor :access_token
 
       def client
-        client_id = options.client_id.respond_to?(:call) ? options.client_id.call : options.client_id
-        client_secret = options.client_secret.respond_to?(:call) ? options.client_secret.call : options.client_secret
         ::OAuth2::Client.new(client_id, client_secret, deep_symbolize(options.client_options))
+      end
+
+      def client_id
+        options.client_id.respond_to?(:call) ? options.client_id.call : options.client_id
+      end
+
+      def client_secret
+        options.client_secret.respond_to?(:call) ? options.client_secret.call : options.client_secret
       end
 
       def callback_url

--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -33,7 +33,9 @@ module OmniAuth
       attr_accessor :access_token
 
       def client
-        ::OAuth2::Client.new(options.client_id, options.client_secret, deep_symbolize(options.client_options))
+        client_id = options.client_id.respond_to?(:call) ? options.client_id.call : options.client_id
+        client_secret = options.client_secret.respond_to?(:call) ? options.client_secret.call : options.client_secret
+        ::OAuth2::Client.new(client_id, client_secret, deep_symbolize(options.client_options))
       end
 
       def callback_url

--- a/spec/omniauth/strategies/oauth2_spec.rb
+++ b/spec/omniauth/strategies/oauth2_spec.rb
@@ -39,13 +39,13 @@ describe OmniAuth::Strategies::OAuth2 do
     end
 
     it "allows client_id to be passed as a lambda function" do
-      client_id = lambda { 'abc' }
+      client_id = -> { 'abc' }
       instance = subject.new(Object, client_id, 'def')
       expect(instance.client.id).to eq('abc')
     end
 
     it "allows client_secret to be passed as a lambda function" do
-      client_secret = lambda { 'def' }
+      client_secret = -> { 'def' }
       instance = subject.new(Object, 'abc', client_secret)
       expect(instance.client.secret).to eq('def')
     end

--- a/spec/omniauth/strategies/oauth2_spec.rb
+++ b/spec/omniauth/strategies/oauth2_spec.rb
@@ -39,15 +39,15 @@ describe OmniAuth::Strategies::OAuth2 do
     end
 
     it "allows client_id to be passed as a lambda function" do
-      client_id = -> { 'abc' }
-      instance = subject.new(Object, client_id, 'def')
-      expect(instance.client.id).to eq('abc')
+      client_id = -> { "abc" }
+      instance = subject.new(Object, client_id, "def")
+      expect(instance.client.id).to eq("abc")
     end
 
     it "allows client_secret to be passed as a lambda function" do
-      client_secret = -> { 'def' }
-      instance = subject.new(Object, 'abc', client_secret)
-      expect(instance.client.secret).to eq('def')
+      client_secret = -> { "def" }
+      instance = subject.new(Object, "abc", client_secret)
+      expect(instance.client.secret).to eq("def")
     end
   end
 

--- a/spec/omniauth/strategies/oauth2_spec.rb
+++ b/spec/omniauth/strategies/oauth2_spec.rb
@@ -37,6 +37,18 @@ describe OmniAuth::Strategies::OAuth2 do
       instance = subject.new(app, :client_options => {"ssl" => {"ca_path" => "foo"}})
       expect(instance.client.options[:connection_opts][:ssl]).to eq(:ca_path => "foo")
     end
+
+    it "allows client_id to be passed as a lambda function" do
+      client_id = lambda { 'abc' }
+      instance = subject.new(Object, client_id, 'def')
+      expect(instance.client.id).to eq('abc')
+    end
+
+    it "allows client_secret to be passed as a lambda function" do
+      client_secret = lambda { 'def' }
+      instance = subject.new(Object, 'abc', client_secret)
+      expect(instance.client.secret).to eq('def')
+    end
   end
 
   describe "#authorize_params" do

--- a/spec/omniauth/strategies/oauth2_spec.rb
+++ b/spec/omniauth/strategies/oauth2_spec.rb
@@ -39,13 +39,13 @@ describe OmniAuth::Strategies::OAuth2 do
     end
 
     it "allows client_id to be passed as a lambda function" do
-      client_id = -> { "abc" }
+      client_id = proc { "abc" }
       instance = subject.new(Object, client_id, "def")
       expect(instance.client.id).to eq("abc")
     end
 
     it "allows client_secret to be passed as a lambda function" do
-      client_secret = -> { "def" }
+      client_secret = proc { "def" }
       instance = subject.new(Object, "abc", client_secret)
       expect(instance.client.secret).to eq("def")
     end


### PR DESCRIPTION
When using omniauth in a multitenant environment, it's useful to have a separate set of credentials for each tenant that need to be selected at runtime based on the target domain/path of a request. This change allows the client_id and client_secret settings to be passed as anonymous functions instead of static values in order to facilitate this.
