### PR TITLE
Fix csrf_detect error with concurrent authorisations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,5 +38,11 @@ Style/SpaceInsideHashLiteralBraces:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/MutableConstant:
+  Enabled: false

--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -42,9 +42,9 @@ module OmniAuth
 
       credentials do
         hash = {"token" => access_token.token}
-        hash.merge!("refresh_token" => access_token.refresh_token) if access_token.expires? && access_token.refresh_token
-        hash.merge!("expires_at" => access_token.expires_at) if access_token.expires?
-        hash.merge!("expires" => access_token.expires?)
+        hash["refresh_token"] = access_token.refresh_token if access_token.expires? && access_token.refresh_token
+        hash["expires_at"] = access_token.expires_at if access_token.expires?
+        hash["expires"] = access_token.expires?
         hash
       end
 
@@ -71,7 +71,7 @@ module OmniAuth
         error = request.params["error_reason"] || request.params["error"]
         if error
           fail!(error, CallbackError.new(request.params["error"], request.params["error_description"] || request.params["error_reason"], request.params["error_uri"]))
-        elsif !options.provider_ignores_state && (request.params["state"].to_s.empty? || session.delete("omniauth.state.#{request.params["state"]}") != "true")
+        elsif !options.provider_ignores_state && (request.params["state"].to_s.empty? || session.delete("omniauth.state.#{request.params['state']}") != "true")
           fail!(:csrf_detected, CallbackError.new(:csrf_detected, "CSRF detected"))
         else
           self.access_token = build_access_token

--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -59,7 +59,7 @@ module OmniAuth
           @env ||= {}
           @env["rack.session"] ||= {}
         end
-        session["omniauth.state"] = params[:state]
+        session["omniauth.state.#{params[:state]}"] = "true"
         params
       end
 
@@ -71,7 +71,7 @@ module OmniAuth
         error = request.params["error_reason"] || request.params["error"]
         if error
           fail!(error, CallbackError.new(request.params["error"], request.params["error_description"] || request.params["error_reason"], request.params["error_uri"]))
-        elsif !options.provider_ignores_state && (request.params["state"].to_s.empty? || request.params["state"] != session.delete("omniauth.state"))
+        elsif !options.provider_ignores_state && (request.params["state"].to_s.empty? || session.delete("omniauth.state.#{request.params["state"]}") != "true")
           fail!(:csrf_detected, CallbackError.new(:csrf_detected, "CSRF detected"))
         else
           self.access_token = build_access_token


### PR DESCRIPTION
Right now, if multiple authorisations are started in different tabs, only the latest will succeed since session's state is overridden each time an authorisation starts.

This fixes that issue by having multiple states within a session rather than just one.

Note: there could still be race conditions when the session information is store is a cookie and a second authorisation is started before the browser has stored the cookie from the first one.
