### PR TITLE
Add state_length option to specify the legth of state parameter

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -29,6 +29,7 @@ module OmniAuth
       option :token_options, []
       option :auth_token_params, {}
       option :provider_ignores_state, false
+      option :state_length, 48
 
       attr_accessor :access_token
 
@@ -49,7 +50,8 @@ module OmniAuth
       end
 
       def authorize_params
-        options.authorize_params[:state] = SecureRandom.hex(24)
+        state_length = options[:state_length]
+        options.authorize_params[:state] = SecureRandom.hex(state_length / 2 + 1)[0...state_length]
         params = options.authorize_params.merge(options_for("authorize"))
         if OmniAuth.config.test_mode
           @env ||= {}


### PR DESCRIPTION
I recently wrote a strategy for a service that only accepts state parameter shorter than 48 characters. The state length is currently hard-coded, so I had to overwrite `options[:state]` in setup_phase, but it would be nice if omniauth-oauth2 had an option to change state parameter length.
