### PR TITLE
Allow to use Proc for generation of state

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -24,7 +24,7 @@ module OmniAuth
       option :client_secret, nil
       option :client_options, {}
       option :authorize_params, {}
-      option :authorize_options, [:scope]
+      option :authorize_options, [:scope, :state]
       option :token_params, {}
       option :token_options, []
       option :auth_token_params, {}
@@ -100,7 +100,11 @@ module OmniAuth
       def options_for(option)
         hash = {}
         options.send(:"#{option}_options").select { |key| options[key] }.each do |key|
-          hash[key.to_sym] = options[key]
+          hash[key.to_sym] = if options[key].respond_to?(:call)
+            options[key].call(env)
+          else
+            options[key]
+          end
         end
         hash
       end

--- a/spec/omniauth/strategies/oauth2_spec.rb
+++ b/spec/omniauth/strategies/oauth2_spec.rb
@@ -52,12 +52,19 @@ describe OmniAuth::Strategies::OAuth2 do
       instance = subject.new("abc", "def", :authorize_options => [:scope, :foo, :state], :scope => "bar", :foo => "baz")
       expect(instance.authorize_params["scope"]).to eq("bar")
       expect(instance.authorize_params["foo"]).to eq("baz")
+      expect(instance.authorize_params["state"]).not_to be_empty
     end
 
     it "includes random state in the authorize params" do
       instance = subject.new("abc", "def")
       expect(instance.authorize_params.keys).to eq(["state"])
       expect(instance.session["omniauth.state"]).not_to be_empty
+    end
+
+    it "includes custom state in the authorize params" do
+      instance = subject.new("abc", "def", state: Proc.new { "qux" } )
+      expect(instance.authorize_params.keys).to eq(["state"])
+      expect(instance.session["omniauth.state"]).to eq("qux")
     end
   end
 


### PR DESCRIPTION
By https://github.com/intridea/omniauth-oauth2/pull/94

Sometimes need to use own value of state.

For example: you can use own encryption for send extra data in state (`expires`, ...).

Also It can be useful if some providers do not support `callback_params` in `callback_url`
