### PR TITLE
Fix redirect_uri so that it does not include `code` or `state`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,5 +38,8 @@ Style/SpaceInsideHashLiteralBraces:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: 'comma'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,11 @@ env:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
   - 2.1
   - 2.2
-  - jruby-18mode
-  - jruby-19mode
+  - 2.3.1
+  - jruby-9
   - jruby-head
-  - rbx-2
   - ruby-head
 matrix:
   allow_failures:

--- a/lib/omniauth-oauth2/version.rb
+++ b/lib/omniauth-oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module OAuth2
-    VERSION = "1.4.0"
+    VERSION = "1.4.0".freeze
   end
 end

--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -56,9 +56,9 @@ module OmniAuth
 
       credentials do
         hash = {"token" => access_token.token}
-        hash.merge!("refresh_token" => access_token.refresh_token) if access_token.expires? && access_token.refresh_token
-        hash.merge!("expires_at" => access_token.expires_at) if access_token.expires?
-        hash.merge!("expires" => access_token.expires?)
+        hash["refresh_token"] = access_token.refresh_token if access_token.expires? && access_token.refresh_token
+        hash["expires_at"] = access_token.expires_at if access_token.expires?
+        hash["expires"] = access_token.expires?
         hash
       end
 

--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -36,6 +36,24 @@ module OmniAuth
         ::OAuth2::Client.new(options.client_id, options.client_secret, deep_symbolize(options.client_options))
       end
 
+      def callback_url
+        # If redirect_uri is configured in token_params, use that
+        # value.
+        token_params.to_hash(:symbolize_keys => true)[:redirect_uri] || super
+      end
+
+      def query_string
+        # This method is called by callback_url, only if redirect_uri
+        # is omitted in token_params.
+        if request.params["code"]
+          # If this is a callback, ignore query parameters added by
+          # the provider.
+          ""
+        else
+          super
+        end
+      end
+
       credentials do
         hash = {"token" => access_token.token}
         hash.merge!("refresh_token" => access_token.refresh_token) if access_token.expires? && access_token.refresh_token

--- a/omniauth-oauth2.gemspec
+++ b/omniauth-oauth2.gemspec
@@ -5,6 +5,8 @@ require "omniauth-oauth2/version"
 Gem::Specification.new do |gem|
   gem.add_dependency "oauth2",     "~> 1.0"
   gem.add_dependency "omniauth",   "~> 1.2"
+  gem.add_dependency "public_suffix", "< 2.0.4" if RUBY_VERSION < "2.0"
+  gem.add_dependency "rack",       "< 2" if RUBY_VERSION < "2.2.2"
 
   gem.add_development_dependency "bundler", "~> 1.0"
 

--- a/spec/omniauth/strategies/oauth2_spec.rb
+++ b/spec/omniauth/strategies/oauth2_spec.rb
@@ -87,6 +87,37 @@ describe OmniAuth::Strategies::OAuth2 do
       instance.callback_phase
     end
   end
+
+  describe "#callback_url" do
+    subject { fresh_strategy }
+
+    it "returns the value in token_params, if given" do
+      instance = subject.new("abc", "def", :token_params => {:redirect_uri => "http://test/foo?bar=1"})
+      allow(instance).to receive(:request) do
+        double("Request", :params => {"code" => "codecodecode", "state" => "statestatestate"})
+      end
+      expect(instance.callback_url).to eq("http://test/foo?bar=1")
+    end
+
+    it "does not include any query parameters like \"code\" and \"state\"" do
+      instance = subject.new("abc", "def")
+      allow(instance).to receive(:full_host) do
+        "http://test"
+      end
+      allow(instance).to receive(:script_name) do
+        "/foo"
+      end
+      allow(instance).to receive(:callback_path) do
+        "/bar/callback"
+      end
+      allow(instance).to receive(:request) do
+        double("Request",
+               :params => {"code" => "codecodecode", "state" => "statestatestate"},
+               :query_string => "code=codecodecode&state=statestatestate")
+      end
+      expect(instance.callback_url).to eq("http://test/foo/bar/callback")
+    end
+  end
 end
 
 describe OmniAuth::Strategies::OAuth2::CallbackError do

--- a/spec/omniauth/strategies/oauth2_spec.rb
+++ b/spec/omniauth/strategies/oauth2_spec.rb
@@ -99,7 +99,26 @@ describe OmniAuth::Strategies::OAuth2 do
       expect(instance.callback_url).to eq("http://test/foo?bar=1")
     end
 
-    it "does not include any query parameters like \"code\" and \"state\"" do
+    it "does not contain any parameters" do
+      instance = subject.new("abc", "def")
+      allow(instance).to receive(:full_host) do
+        "http://test"
+      end
+      allow(instance).to receive(:script_name) do
+        "/foo"
+      end
+      allow(instance).to receive(:callback_path) do
+        "/bar/callback"
+      end
+      allow(instance).to receive(:request) do
+        double("Request",
+               :params => {},
+               :query_string => "")
+      end
+      expect(instance.callback_url).to eq("http://test/foo/bar/callback")
+    end
+
+    it "does not include any query parameters when invoked from within a callback" do
       instance = subject.new("abc", "def")
       allow(instance).to receive(:full_host) do
         "http://test"


### PR DESCRIPTION
I think this is a better fix for #28, and saves many OAuth2 strategies broken by #70.