### PR TITLE
Bring `omniauth-oauth2` up-to-date

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,9 @@
+Layout/AccessModifierIndentation:
+  EnforcedStyle: outdent
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+
 Metrics/BlockNesting:
   Max: 2
 
@@ -12,9 +18,6 @@ Metrics/MethodLength:
 Metrics/ParameterLists:
   Max: 4
   CountKeywordArgs: true
-
-Style/AccessModifierIndentation:
-  EnforcedStyle: outdent
 
 Style/CollectionMethods:
   PreferredMethods:
@@ -32,11 +35,10 @@ Style/DoubleNegation:
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
 
-Style/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
+
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: 'comma'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,7 +35,8 @@ Style/DoubleNegation:
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
 
-
+Style/StderrPuts:
+  Enabled: false
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,12 @@ env:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1
-  - 2.2
-  - jruby-18mode
-  - jruby-19mode
+  - jruby-9000
+  - 2.1.10 # EOL Soon
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
   - jruby-head
-  - rbx-2
   - ruby-head
 matrix:
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :test do
   gem "rack-test"
   gem "rest-client", "~> 1.7.3", :platforms => %i[jruby ruby_18]
   gem "rspec", "~> 3.2"
-  gem "rubocop", ">= 0.30", :platforms => %i[ruby_19 ruby_20 ruby_21 ruby_22]
+  gem "rubocop", ">= 0.51", :platforms => %i[ruby_19 ruby_20 ruby_21 ruby_22]
   gem "simplecov", ">= 0.9"
   gem "webmock"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :test do
   gem "json", :platforms => [:jruby, :ruby_18, :ruby_19]
   gem "mime-types", "~> 1.25", :platforms => [:jruby, :ruby_18]
   gem "rack-test"
-  gem "rest-client", "~> 1.6.0", :platforms => [:jruby, :ruby_18]
+  gem "rest-client", "~> 1.7.3", :platforms => [:jruby, :ruby_18]
   gem "rspec", "~> 3.2"
   gem "rubocop", ">= 0.30", :platforms => [:ruby_19, :ruby_20, :ruby_21, :ruby_22]
   gem "simplecov", ">= 0.9"

--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,12 @@ gem "rake"
 
 group :test do
   gem "coveralls"
-  gem "json", :platforms => [:jruby, :ruby_18, :ruby_19]
-  gem "mime-types", "~> 1.25", :platforms => [:jruby, :ruby_18]
+  gem "json", :platforms => %i[jruby ruby_18 ruby_19]
+  gem "mime-types", "~> 1.25", :platforms => %i[jruby ruby_18]
   gem "rack-test"
-  gem "rest-client", "~> 1.7.3", :platforms => [:jruby, :ruby_18]
+  gem "rest-client", "~> 1.7.3", :platforms => %i[jruby ruby_18]
   gem "rspec", "~> 3.2"
-  gem "rubocop", ">= 0.30", :platforms => [:ruby_19, :ruby_20, :ruby_21, :ruby_22]
+  gem "rubocop", ">= 0.30", :platforms => %i[ruby_19 ruby_20 ruby_21 ruby_22]
   gem "simplecov", ">= 0.9"
   gem "webmock"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -15,4 +15,4 @@ rescue LoadError
   end
 end
 
-task :default => [:spec, :rubocop]
+task :default => %i[spec rubocop]

--- a/lib/omniauth-oauth2/version.rb
+++ b/lib/omniauth-oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module OAuth2
-    VERSION = "1.4.0"
+    VERSION = "1.4.0".freeze
   end
 end

--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -18,7 +18,7 @@ module OmniAuth
         OmniAuth::Strategy.included(subclass)
       end
 
-      args [:client_id, :client_secret]
+      args %i[client_id client_secret]
 
       option :client_id, nil
       option :client_secret, nil
@@ -38,9 +38,9 @@ module OmniAuth
 
       credentials do
         hash = {"token" => access_token.token}
-        hash.merge!("refresh_token" => access_token.refresh_token) if access_token.expires? && access_token.refresh_token
-        hash.merge!("expires_at" => access_token.expires_at) if access_token.expires?
-        hash.merge!("expires" => access_token.expires?)
+        hash["refresh_token"] = access_token.refresh_token if access_token.expires? && access_token.refresh_token
+        hash["expires_at"] = access_token.expires_at if access_token.expires?
+        hash["expires"] = access_token.expires?
         hash
       end
 

--- a/omniauth-oauth2.gemspec
+++ b/omniauth-oauth2.gemspec
@@ -13,12 +13,12 @@ Gem::Specification.new do |gem|
   gem.description   = "An abstract OAuth2 strategy for OmniAuth."
   gem.summary       = gem.description
   gem.homepage      = "https://github.com/intridea/omniauth-oauth2"
-  gem.licenses      = %w(MIT)
+  gem.licenses      = %w[MIT]
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").collect { |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.name          = "omniauth-oauth2"
-  gem.require_paths = %w(lib)
+  gem.require_paths = %w[lib]
   gem.version       = OmniAuth::OAuth2::VERSION
 end

--- a/omniauth-oauth2.gemspec
+++ b/omniauth-oauth2.gemspec
@@ -8,11 +8,11 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "bundler", "~> 1.0"
 
-  gem.authors       = ["Michael Bleigh", "Erik Michaels-Ober"]
-  gem.email         = ["michael@intridea.com", "sferik@gmail.com"]
+  gem.authors       = ["Michael Bleigh", "Erik Michaels-Ober", "Tom Milewski"]
+  gem.email         = ["michael@intridea.com", "sferik@gmail.com", "tmilewski@gmail.com"]
   gem.description   = "An abstract OAuth2 strategy for OmniAuth."
   gem.summary       = gem.description
-  gem.homepage      = "https://github.com/intridea/omniauth-oauth2"
+  gem.homepage      = "https://github.com/omniauth/omniauth-oauth2"
   gem.licenses      = %w[MIT]
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").collect { |f| File.basename(f) }

--- a/spec/omniauth/strategies/oauth2_spec.rb
+++ b/spec/omniauth/strategies/oauth2_spec.rb
@@ -1,6 +1,6 @@
 require "helper"
 
-describe OmniAuth::Strategies::OAuth2 do
+describe OmniAuth::Strategies::OAuth2 do # rubocop:disable Metrics/BlockLength
   def app
     lambda do |_env|
       [200, {}, ["Hello."]]
@@ -49,7 +49,7 @@ describe OmniAuth::Strategies::OAuth2 do
     end
 
     it "includes top-level options that are marked as :authorize_options" do
-      instance = subject.new("abc", "def", :authorize_options => [:scope, :foo, :state], :scope => "bar", :foo => "baz")
+      instance = subject.new("abc", "def", :authorize_options => %i[scope foo state], :scope => "bar", :foo => "baz")
       expect(instance.authorize_params["scope"]).to eq("bar")
       expect(instance.authorize_params["foo"]).to eq("baz")
     end
@@ -70,7 +70,7 @@ describe OmniAuth::Strategies::OAuth2 do
     end
 
     it "includes top-level options that are marked as :authorize_options" do
-      instance = subject.new("abc", "def", :token_options => [:scope, :foo], :scope => "bar", :foo => "baz")
+      instance = subject.new("abc", "def", :token_options => %i[scope foo], :scope => "bar", :foo => "baz")
       expect(instance.token_params).to eq("scope" => "bar", "foo" => "baz")
     end
   end


### PR DESCRIPTION
- Fix `rest-api` vulnerability
- Update to match Omniauth and Ruby support
- Fix Rubocop Offenses
