### PR TITLE
CI against Ruby 2.2.9, 2.3.6, and 2.4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ language: ruby
 rvm:
   - jruby-9000
   - 2.1.10 # EOL Soon
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
   - jruby-head
   - ruby-head
 matrix:


### PR DESCRIPTION
These Ruby versions are released and available on Travis CI.

https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-4-3-released/
https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-3-6-released/
https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-2-9-released/