### PR TITLE
Allow site to be specified in the args.

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -18,10 +18,11 @@ module OmniAuth
         OmniAuth::Strategy.included(subclass)
       end
 
-      args %i[client_id client_secret]
+      args %i[client_id client_secret site]
 
       option :client_id, nil
       option :client_secret, nil
+      option :site, nil
       option :client_options, {}
       option :authorize_params, {}
       option :authorize_options, [:scope]
@@ -33,6 +34,10 @@ module OmniAuth
       attr_accessor :access_token
 
       def client
+        if options.site
+          options.client_options[:site] = options.site
+        end
+
         ::OAuth2::Client.new(options.client_id, options.client_secret, deep_symbolize(options.client_options))
       end
 


### PR DESCRIPTION
I've encountered a situation where different development environments have a different site url. I would like to specify the site in the env vars, similar to how it's done with the key and secret.

This should be completely optional, so it's written as such.