### PR TITLE
Prevent timing attack on CSRF

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -106,14 +106,14 @@ module OmniAuth
       end
 
       # constant-time comparison algorithm to prevent timing attacks
-      def secure_compare(a, b)
-        return false unless a.bytesize == b.bytesize
+      def secure_compare(string_a, string_b)
+        return false unless string_a.bytesize == string_b.bytesize
 
-        l = a.unpack "C#{a.bytesize}"
+        l = string_a.unpack "C#{string_a.bytesize}"
 
         res = 0
-        b.each_byte { |byte| res |= byte ^ l.shift }
-        res == 0
+        string_b.each_byte { |byte| res |= byte ^ l.shift }
+        res.zero?
       end
 
       # An error that is indicated in the OAuth 2.0 callback.

--- a/spec/omniauth/strategies/oauth2_spec.rb
+++ b/spec/omniauth/strategies/oauth2_spec.rb
@@ -87,6 +87,16 @@ describe OmniAuth::Strategies::OAuth2 do # rubocop:disable Metrics/BlockLength
       instance.callback_phase
     end
   end
+
+  describe "#secure_params" do
+    subject { fresh_strategy }
+
+    it "returns true when the two inputs are the same and false otherwise" do
+      instance = subject.new("abc", "def")
+      expect(instance.send(:secure_compare, "a", "a")).to be true
+      expect(instance.send(:secure_compare, "b", "a")).to be false
+    end
+  end
 end
 
 describe OmniAuth::Strategies::OAuth2::CallbackError do


### PR DESCRIPTION
use secure_compare instead of plain equality comparison on request and callback state to prevent timing attacks. 