### PR TITLE
Update oauth2 to ~> 1.4

### DIFF
--- a/omniauth-oauth2.gemspec
+++ b/omniauth-oauth2.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "omniauth-oauth2/version"
 
 Gem::Specification.new do |gem|
-  gem.add_dependency "oauth2",     "~> 1.1"
+  gem.add_dependency "oauth2",     "~> 1.4"
   gem.add_dependency "omniauth",   "~> 1.9"
 
   gem.add_development_dependency "bundler", "~> 1.0"


### PR DESCRIPTION
Updates oauth2 dependency to the most recent version. The current version, ~>1.1, is over a year old.

Big advantage of using a newer version of oauth2 is that it allows for more recent versions of faraday. https://github.com/oauth-xx/oauth2/blob/master/oauth2.gemspec#L8

Went over the [changelog](https://github.com/oauth-xx/oauth2/blob/master/CHANGELOG.md) and there seem to be no changes since 1.1.1 that would affect omniauth-oauth2