### PR TITLE
update version of oauth2 for faraday

### DIFF
--- a/omniauth-oauth2.gemspec
+++ b/omniauth-oauth2.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "omniauth-oauth2/version"
 
 Gem::Specification.new do |gem|
-  gem.add_dependency "oauth2",     "~> 1.4"
+  gem.add_dependency "oauth2",     "~> 1.4.1"
   gem.add_dependency "omniauth",   "~> 1.9"
 
   gem.add_development_dependency "bundler", "~> 1.0"


### PR DESCRIPTION
This pull request is to update version of oauth2, because is need update the faraday minimum version for rails 6 and new omniauth