### PR TITLE
Rescue Faraday timeout errors

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -76,7 +76,7 @@ module OmniAuth
         end
       rescue ::OAuth2::Error, CallbackError => e
         fail!(:invalid_credentials, e)
-      rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
+      rescue ::Timeout::Error, ::Errno::ETIMEDOUT, ::Faraday::TimeoutError, ::Faraday::ConnectionFailed => e
         fail!(:timeout, e)
       rescue ::SocketError => e
         fail!(:failed_to_connect, e)


### PR DESCRIPTION
In the event of a `Net::ReadTimeout`, Faraday raises
`Faraday::TimeoutError`, and for `Net::OpenTimeout` it raises
`Faraday::ConnectionFailed`. These errors may be encountered
when specifying a timeout for Faraday via
`client_options: { connection_opts: { request: { open_timeout: 30, timeout: 30 } } }`
and if the request takes longer than those timeout values in seconds.

We are setting these timeouts for omniauth-google-oauth2 as we're sometimes seeing the OAuth requests take longer than 60 seconds. Not sure why Google is taking so long to respond, but in any case, setting a sane timeout is helpful in these cases so users don't need to wait. But if an error is raised we can't rescue it within our app and need it to be handled as a proper omniauth failure. 

If you want me to write some tests, happy to take a look. I tried to find some existing examples or simple ways to test and it didn't seem all that useful - it would be stubbing Faraday or something within this gem. But happy to take a look again if you would like. 