### PR TITLE
Add extra info logs to aid debugging of state error

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -70,8 +70,9 @@ module OmniAuth
           error_uri = request.params["error_uri"]
           fail!(error, CallbackError.new(request.params["error"], description, error_uri))
         elsif !options.provider_ignores_state && (actual_state.empty? || actual_state != expected_state)
-          fail!(:csrf_detected, CallbackError.new(:csrf_detected, "CSRF detected"))
+          fail!(:csrf_detected, CallbackError.new(:csrf_detected, "CSRF detected", state_store: state_store, expected: expected_state, actual: actual_state))
         else
+          log :info, "State verified and cleared - #{actual_state}"
           state_store.delete(site)
           self.access_token = build_access_token
           self.access_token = access_token.refresh! if access_token.expired?

--- a/spec/omniauth/strategies/oauth2_spec.rb
+++ b/spec/omniauth/strategies/oauth2_spec.rb
@@ -53,11 +53,49 @@ describe OmniAuth::Strategies::OAuth2 do # rubocop:disable Metrics/BlockLength
       expect(instance.authorize_params["scope"]).to eq("bar")
       expect(instance.authorize_params["foo"]).to eq("baz")
     end
+  end
 
-    it "includes random state in the authorize params" do
-      instance = subject.new("abc", "def")
-      expect(instance.authorize_params.keys).to eq(["state"])
-      expect(instance.session["omniauth.state"]).not_to be_empty
+  describe "state handling" do
+    SocialNetwork = Class.new(OmniAuth::Strategies::OAuth2)
+
+    let(:client_options) { {:site => "https://graph.example.com"} }
+    let(:instance) { SocialNetwork.new(-> env {}) }
+
+    before do
+      allow(SecureRandom).to receive(:hex).with(24).and_return("hex-1", "hex-2")
+    end
+
+    it "includes a state scoped to the client" do
+      expect(instance.authorize_params["state"]).to eq("hex-1")
+      expect(instance.session["omniauth.oauth2.state"]).to eq("SocialNetwork" => "hex-1")
+    end
+
+    context "once a state value has been generated" do
+      before do
+        instance.authorize_params
+      end
+
+      it "does not replace an existing session value" do
+        expect(instance.authorize_params["state"]).to eq("hex-1")
+        expect(instance.session["omniauth.oauth2.state"]).to eq("SocialNetwork" => "hex-1")
+      end
+    end
+
+    context "on a successful callback" do
+      let(:request) { double("Request", :params => {"code" => "auth-code", "state" => "hex-1"}) }
+      let(:access_token) { double("AccessToken", :expired? => false, :expires? => false, :token => "access-token") }
+
+      before do
+        allow(instance).to receive(:request).and_return(request)
+        allow(instance).to receive(:build_access_token).and_return(access_token)
+
+        instance.authorize_params
+        instance.callback_phase
+      end
+
+      it "removes the value from the session" do
+        expect(instance.session["omniauth.oauth2.state"]).to eq({})
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds logging:

1. to check when the session state is successfully verified - and therefore cleared
2. and the values being compared when there is a verification error.

It also includes the "fix" we previously deployed.