### PR TITLE
Verify state before using errors received from provider

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -83,10 +83,10 @@ module OmniAuth
 
       def callback_phase # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
         error = request.params["error_reason"] || request.params["error"]
-        if error
-          fail!(error, CallbackError.new(request.params["error"], request.params["error_description"] || request.params["error_reason"], request.params["error_uri"]))
-        elsif !options.provider_ignores_state && (request.params["state"].to_s.empty? || request.params["state"] != session.delete("omniauth.state"))
+        if !options.provider_ignores_state && (request.params["state"].to_s.empty? || request.params["state"] != session.delete("omniauth.state"))
           fail!(:csrf_detected, CallbackError.new(:csrf_detected, "CSRF detected"))
+        elsif error
+          fail!(error, CallbackError.new(request.params["error"], request.params["error_description"] || request.params["error_reason"], request.params["error_uri"]))
         else
           self.access_token = build_access_token
           self.access_token = access_token.refresh! if access_token.expired?


### PR DESCRIPTION
### Summary

This avoids content spoofing attacks by crafting a URL with malicious messages, because the `state` param is only present in the session after a valid OAuth2 authentication flow.

### Background

This vulnerability was reported to GitLab in https://gitlab.com/gitlab-org/gitlab/-/issues/27241 and patched for the 14.3.1 security release in https://gitlab.com/gitlab-org/gitlab/-/commit/79457dafe55. We haven't encountered any problems with this change in our testing and usage.

An example URL to exploit this is https://gitlab.com/users/auth/bitbucket/callback?state=cae8687aa809fc45e00b2f8ed4a0ea124d5f9b8235cb2b2e&error_description=YOUR+ACCOUNT+WAS+LOCKED,PLEASE+GO+TO+https://evil.com+FOR+UNLOCKING+YOUR+ACCOUNT&error=access_denied, previously this would render the attacker's URL in the flash message (which IIRC is the default behaviour when using OmniAuth with Devise), but after this change we'll get the CSRF error instead.

The vulnerability is pretty minor overall, but the fix is also simple so I think this would be worth upstreaming :grinning: 