### PR TITLE
Add Ruby 3.0 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby: [2.5, 2.6, 2.7, head, debug, truffleruby, truffleruby-head]
+        ruby: [2.5, 2.6, 2.7, '3.0', head, debug, truffleruby, truffleruby-head]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
This PR just adds Ruby 3.0 to the CI matrix.