### PR TITLE
:wrench: Relax gem 'oauth2' dependency requirement

### DIFF
--- a/omniauth-oauth2.gemspec
+++ b/omniauth-oauth2.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "omniauth-oauth2/version"
 
 Gem::Specification.new do |gem|
-  gem.add_dependency "oauth2",     "~> 1.4"
+  gem.add_dependency "oauth2",     [">= 1.4", "< 3"]
   gem.add_dependency "omniauth",   [">= 1.9", "< 3"]
 
   gem.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
I want to use [oauth 2.0.0](https://github.com/oauth-xx/oauth2), but I can't because the dependency requirement are to strict.

This Pull Request fixes that.