### PR TITLE
Unwrap OAuth2::Error

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -92,8 +92,10 @@ module OmniAuth
           self.access_token = access_token.refresh! if access_token.expired?
           super
         end
-      rescue ::OAuth2::Error, CallbackError => e
-        fail!(:invalid_credentials, e)
+      rescue ::OAuth2::Error => e
+        fail!(e.code, e)
+      rescue ::CallbackError => e
+        fail!(e.error, e)
       rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
         fail!(:timeout, e)
       rescue ::SocketError => e


### PR DESCRIPTION
In case an error is raised within the OAuth2 request() it would make sense to forward the error kind.

At least the `invalid_credentials` currently returned doesn't capture all errors which can occur during request_phase.