### PR TITLE
Use omniauth 2.x to ensure latest security updates

### DIFF
--- a/omniauth-oauth2.gemspec
+++ b/omniauth-oauth2.gemspec
@@ -4,7 +4,7 @@ require "omniauth-oauth2/version"
 
 Gem::Specification.new do |gem|
   gem.add_dependency "oauth2",     "~> 1.4"
-  gem.add_dependency "omniauth",   [">= 1.9", "< 3"]
+  gem.add_dependency "omniauth",   "~> 2.0"
 
   gem.add_development_dependency "bundler", "~> 2.0"
 


### PR DESCRIPTION
My team have been working on some security updates on our app and we noticed `omniauth-oauth2` was listing any version from `omniauth` between 1.9 and 3 as a valid dependency. bc of that we kept running on [this](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284) security issue. We manually enforced `omniauth` 2.x on our Gemfile to solve it, but I thought it may be useful to bump the version directly on the gem since the issue seems to exist on all 1.9.x versions
