### PR TITLE
Relax oauth2 dependency

### DIFF
--- a/omniauth-oauth2.gemspec
+++ b/omniauth-oauth2.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "omniauth-oauth2/version"
 
 Gem::Specification.new do |gem|
-  gem.add_dependency "oauth2",     "~> 1.4"
+  gem.add_dependency "oauth2",     [">= 1.4", "< 3"]
   gem.add_dependency "omniauth",   [">= 1.9", "< 3"]
 
   gem.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
The oauth2 gem will be releasing v2.0 soon, as all issues in
https://github.com/oauth-xx/oauth2/milestone/1 are complete. This gem
appears to be fully compatible, so loosen the dependency to allow for
2.0.