### PR TITLE
Remove unnecessary executable bit from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-#!/usr/bin/env rake
-
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 


### PR DESCRIPTION
The Rakefile is not executed directly but is instead executed through the rake command. This entry point doesn't require the file include the executable bit.