### PR TITLE
Rescue OAuth2 Timeout errors

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -94,7 +94,7 @@ module OmniAuth
         end
       rescue ::OAuth2::Error, CallbackError => e
         fail!(:invalid_credentials, e)
-      rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
+      rescue ::Timeout::Error, ::Errno::ETIMEDOUT, OAuth2::TimeoutError, OAuth2::ConnectionError => e
         fail!(:timeout, e)
       rescue ::SocketError => e
         fail!(:failed_to_connect, e)

--- a/omniauth-oauth2.gemspec
+++ b/omniauth-oauth2.gemspec
@@ -4,7 +4,7 @@ require "omniauth-oauth2/version"
 
 Gem::Specification.new do |gem|
   gem.add_dependency "oauth2",     [">= 1.4", "< 3"]
-  gem.add_dependency "omniauth",   "~> 2.0"
+  gem.add_dependency "omniauth",   "~> 2.0.2"
 
   gem.add_development_dependency "bundler", "~> 2.0"
 


### PR DESCRIPTION
* This fix was originally proposed with a different solution via this PR: https://github.com/omniauth/omniauth-oauth2/pull/129
* The conclusion there was that we should not rescue Faraday errors because Faraday is not a direct dependency of OAuth2.
* Instead, best to rescue Faraday errors on OAuth2, then rescue OAuth2 errors here
* Those changes to OAuth2 were made here: https://gitlab.com/oauth-xx/oauth2/-/merge_requests/604 and here https://github.com/oauth-xx/oauth2/pull/549
* And released as part of OAuth2 gem version 2.0.2: https://gitlab.com/oauth-xx/oauth2/-/blob/866dc365bfe0d64f6cc56295a38ccd5b24143836/CHANGELOG.md#L74