### PR TITLE
Exclude spec files from gem package

### DIFF
--- a/omniauth-oauth2.gemspec
+++ b/omniauth-oauth2.gemspec
@@ -16,8 +16,7 @@ Gem::Specification.new do |gem|
   gem.licenses      = %w[MIT]
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").collect { |f| File.basename(f) }
-  gem.files         = `git ls-files`.split("\n")
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  gem.files         = `git ls-files`.split("\n").grep_v(%r{spec/})
   gem.name          = "omniauth-oauth2"
   gem.require_paths = %w[lib]
   gem.version       = OmniAuth::OAuth2::VERSION


### PR DESCRIPTION
Here's a patch that excludes files under spec directory from the gem package.

With this patch, the gem package size shrinks as follows:
```
before: 11776 bytes
after:  10240 bytes
```