### PR TITLE
Updated CI configurations 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, head, debug, truffleruby, truffleruby-head, jruby, jruby-head]
+        ruby: [2.6, 2.7, '3.0', 3.1, 3.2, 3.3, head, debug, truffleruby, truffleruby-head, jruby, jruby-head]
+        include:
+          - { os: macos-13, ruby: '2.5' }
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head, debug, truffleruby, truffleruby-head, jruby, jruby-head]
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, head, debug, truffleruby, truffleruby-head, jruby, jruby-head]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -27,7 +27,7 @@ jobs:
       if: ${{ startsWith(matrix.ruby, 'jruby') }}
     - name: Run tests
       run: bundle exec rake
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.ruby == '3.0' }}
       with:
         name: coverage
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: coverage
         path: coverage/


### PR DESCRIPTION
- Added ruby 3.3
- Updated actions/checkout, actions/upload-artifact, and actions/download-artifact to the latest version
- Since Ruby 2.5 does not work on macos-latest, changed to use macos-13 instead.
- Please refer to this link for the CI results.
    - [CRuby < 2.6 does not support macos-latest now · willnet/omniauth-oauth2@31c21a7](https://github.com/willnet/omniauth-oauth2/actions/runs/11155586002)
    - The cause of the test failures in TruffleRuby is unclear. They pass without any issues on my local Mac environment (M1).