### PR TITLE
Fix Option `pkce_verifier` Cannot be Set Due to Overwrites

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -105,7 +105,7 @@ module OmniAuth
       def pkce_authorize_params
         return {} unless options.pkce
 
-        options.pkce_verifier = SecureRandom.hex(64)
+        options.pkce_verifier ||= SecureRandom.hex(64)
 
         # NOTE: see https://tools.ietf.org/html/rfc7636#appendix-A
         {


### PR DESCRIPTION
### Description

The `option :pkce_verifier, nil` is available to be set in the OAuth Strategy configuration. However, it is being overwritten later in the `#pkce_authorize_params` function. We should only assign the default value when it is not set. This PR resolves the issue.